### PR TITLE
Fix failed create DB

### DIFF
--- a/tasks/configure.yml
+++ b/tasks/configure.yml
@@ -14,15 +14,6 @@
     state: started
   when: ansible_pdm_mailserver_db_mysql_install
 
-- name: Create database for mail server
-  mysql_db:
-    login_host: "{{ ansible_pdm_mailserver_db_host }}"
-    login_user: "{{ ansible_pdm_mailserver_db_admin_username }}"
-    login_password: "{{ ansible_pdm_mailserver_db_admin_password }}"
-    name: "{{ ansible_pdm_mailserver_db_database }}"
-    state: present
-  register: ansible_pdm_mailserver_db_created
-
 - name: Create database user for mail server
   mysql_user:
     append_privs: yes
@@ -34,6 +25,15 @@
     state: present
     host: "%"
     priv: "{{ ansible_pdm_mailserver_db_database }}.*:ALL"
+
+- name: Create database for mail server
+  mysql_db:
+    login_host: "{{ ansible_pdm_mailserver_db_host }}"
+    login_user: "{{ ansible_pdm_mailserver_db_admin_username }}"
+    login_password: "{{ ansible_pdm_mailserver_db_admin_password }}"
+    name: "{{ ansible_pdm_mailserver_db_database }}"
+    state: present
+  register: ansible_pdm_mailserver_db_created
 
 - name: Copy import.sql
   template:


### PR DESCRIPTION
We revert the order between creating table and user to fix an error:

```

fatal: [192.168.33.102]: FAILED! => {
    "changed": false, 
    "invocation": {
        "module_args": {
            "collation": "", 
            "config_file": "/root/.my.cnf", 
            "connect_timeout": 30, 
            "encoding": "", 
            "login_host": "127.0.0.1", 
            "login_password": "VALUE_SPECIFIED_IN_NO_LOG_PARAMETER", 
            "login_port": 3306, 
            "login_unix_socket": null, 
            "login_user": "root", 
            "name": "mailserver", 
            "quick": true, 
            "single_transaction": false, 
            "ssl_ca": null, 
            "ssl_cert": null, 
            "ssl_key": null, 
            "state": "present", 
            "target": null
        }
    }, 
    "msg": "unable to find /root/.my.cnf. Exception message: (1045, \"Access denied for user 'root'@'localhost' (using password: YES)\")"
}
```