### PR TITLE
Make AWS setup optional

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -17,6 +17,7 @@ ansible_pdm_mailserver_db_admin_username: "root"
 ansible_pdm_mailserver_db_database: "mailserver"
 ansible_pdm_mailserver_db_host: 127.0.0.1
 ansible_pdm_mailserver_db_mysql_install: true
+ansible_pdm_mailserver_nginx_install: true
 ansible_pdm_mailserver_db_password: "password"
 ansible_pdm_mailserver_db_username: "mailuser"
 

--- a/tasks/configure.yml
+++ b/tasks/configure.yml
@@ -380,6 +380,8 @@
 - name: Gather AWS facts
   action: ec2_facts
   register: ec2_vars
+  when: ansible_ec2_instance_id is defined
+    and ansible_pdm_mailserver_aws_r53_zone
 
 - name: Ensures S3 backup and restore scripts
   become: yes
@@ -403,6 +405,8 @@
     name: Backup dovecot
     minute: 0
     weekday: 1-7
+  when: ansible_ec2_instance_id is defined
+    and ansible_pdm_mailserver_aws_r53_zone
 
 - name: Restore mail from s3
   become: yes

--- a/tasks/configure.yml
+++ b/tasks/configure.yml
@@ -555,7 +555,7 @@
     state: started
   when: ansible_pdm_mailserver_redis_install
 
-- name: Start redis
+- name: Start nginx
   service:
     name: nginx
     state: started

--- a/tasks/configure.yml
+++ b/tasks/configure.yml
@@ -327,6 +327,7 @@
     dest: /etc/nginx/sites-available/autoconfig.conf
   notify:
     - reload nginx
+  when: ansible_pdm_mailserver_nginx_install
 
 - name: Enable autoconfig site
   file:
@@ -335,6 +336,7 @@
     state: link
   notify:
     - reload nginx
+  when: ansible_pdm_mailserver_nginx_install
 
 - name: Fix Fail2Ban Systemd backend
   ini_file:
@@ -553,6 +555,12 @@
     state: started
   when: ansible_pdm_mailserver_redis_install
 
+- name: Start redis
+  service:
+    name: nginx
+    state: started
+  when: ansible_pdm_mailserver_nginx_install
+
 - name: Start core services
   service:
     name: "{{ item }}"
@@ -564,4 +572,3 @@
     - opendkim
     - postfix
     - dovecot
-    - nginx

--- a/tasks/install.yml
+++ b/tasks/install.yml
@@ -139,6 +139,7 @@
     - /etc/nginx/sites-available
   notify:
     - reload nginx
+  when: ansible_pdm_mailserver_nginx_install
 
 - name: Remove default Nginx site
   file:
@@ -150,6 +151,7 @@
     - /etc/nginx/sites-available/default
   notify:
     - reload nginx
+  when: ansible_pdm_mailserver_nginx_install
 
 - name: Create Nginx config
   copy:
@@ -160,6 +162,7 @@
     src: etc_nginx_nginx.conf
   notify:
     - reload nginx
+  when: ansible_pdm_mailserver_nginx_install
 
 - name: Create postfix maps directory
   file:


### PR DESCRIPTION
Make AWS setup optional to avoid it failing on 
```
TASK [lobsterdore.ansible-pdm-mailserver : Gather AWS facts] *******************
fatal: [192.168.33.102]: FAILED! => {"changed": false, "module_stderr": "Shared connection to 192.168.33.102 closed.\r\n", "module_stdout": "Traceback (most recent call last):\r\n  File \"/tmp/ansible_YoLxJS/ansible_module_ec2_facts.py\", line 544, in <module>\r\n    main()\r\n  File \"/tmp/ansible_YoLxJS/ansible_module_ec2_facts.py\", line 537, in main\r\n    ec2_metadata_facts = Ec2Metadata(module).run()\r\n  File \"/tmp/ansible_YoLxJS/ansible_module_ec2_facts.py\", line 522, in run\r\n    data['ansible_ec2_placement_region'] = data['ansible_ec2_instance_identity_document_region']\r\nKeyError: 'ansible_ec2_instance_identity_document_region'\r\n", "msg": "MODULE FAILURE", "rc": 0}
```